### PR TITLE
Check for inconsistent CIRCUITPY and display CircuitPython update message

### DIFF
--- a/adafruit_pycamera/__init__.py
+++ b/adafruit_pycamera/__init__.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: MIT
 """Library for the Adafruit PyCamera with OV5640 autofocus module"""
 
+# pylint: disable=too-many-lines
+
 import os
 import struct
 import time
@@ -275,6 +277,32 @@ class PyCameraBase:  # pylint: disable=too-many-instance-attributes,too-many-pub
         self._card_power = make_expander_output(_AW_SDPWR, True)
 
         self.mute = make_expander_output(_AW_MUTE, False)
+
+        self.check_for_update_needed()
+
+    def check_for_update_needed(self):
+        """Check whether CIRCUITPY is too big, indicating it was created
+        by a version of CircuitPython older than 9.0.0 beta 2.
+        If so display and print a message and hang.
+        """
+        circuitpy_stat = os.statvfs("/")
+        # CIRCUITPY should be 960KB or so. >1MB is too large
+        # and indicates an older version of CircuitPython
+        # created the filesystem.
+        if circuitpy_stat[1] * circuitpy_stat[2] > 1000000:
+            message = """\
+CIRCUITPY problem.
+Backup. Update CPy
+to >= 9.0.0-beta.2.
+Reformat:
+ import storage
+ storage.erase_
+filesystem()
+See Learn Guide."""
+            self.display_message(message, color=0xFFFFFF, scale=2, full_screen=True)
+            print(message)
+            while True:
+                pass
 
     def make_camera_ui(self):
         """Create displayio widgets for the standard camera UI"""
@@ -678,13 +706,15 @@ class PyCameraBase:  # pylint: disable=too-many-instance-attributes,too-many-pub
         self._display_bus = None
         self.display = None
 
-    def display_message(self, message, color=0xFF0000, scale=3):
+    def display_message(self, message, color=0xFF0000, scale=3, full_screen=False):
         """Display a message on the TFT"""
         text_area = label.Label(terminalio.FONT, text=message, color=color, scale=scale)
-        text_area.anchor_point = (0.5, 0.5)
+        text_area.anchor_point = (0, 0) if full_screen else (0.5, 0.5)
         if not self.display:
             self.init_display()
-        text_area.anchored_position = (self.display.width / 2, self.display.height / 2)
+        text_area.anchored_position = (
+            (0, 0) if full_screen else (self.display.width / 2, self.display.height / 2)
+        )
 
         # Show it
         self.splash.append(text_area)
@@ -994,6 +1024,7 @@ class PyCamera(PyCameraBase):
         self.init_neopixel()
         self.init_display()
         self.init_camera(init_autofocus)
+
         try:
             self.mount_sd_card()
         except Exception as exc:  # pylint: disable=broad-exception-caught

--- a/examples/basic_camera/code.py
+++ b/examples/basic_camera/code.py
@@ -1,16 +1,16 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023 john park for Adafruit Industries
 #
 # SPDX-License-Identifier: MIT
-''' simple point-and-shoot camera example. No bells! Zero whistles! '''
+""" simple point-and-shoot camera example. No bells! Zero whistles! """
 
 import time
-import adafruit_pycamera # pylint: disable=import-error
+import adafruit_pycamera  # pylint: disable=import-error
 
 pycam = adafruit_pycamera.PyCamera()
 pycam.mode = 0  # only mode 0 (JPEG) will work in this example
 
 # User settings - try changing these:
-pycam.resolution = 8    # 0-12 preset resolutions:
+pycam.resolution = 8  # 0-12 preset resolutions:
 #                      0: 240x240, 1: 320x240, 2: 640x480, 3: 800x600, 4: 1024x768,
 #                      5: 1280x720, 6: 1280x1024, 7: 1600x1200, 8: 1920x1080, 9: 2048x1536,
 #                      10: 2560x1440, 11: 2560x1600, 12: 2560x1920


### PR DESCRIPTION
Check for a CIRCUITPY drive that is too large, which indicates that CIRCUITPY was created by a version of CircuitPython older than 9.0.0 beta 2. If so, display and print a message, and hang.

Punctuation has changed slightly since this screen shot.

![img_3018_720](https://github.com/adafruit/Adafruit_CircuitPython_PyCamera/assets/2847802/c3baac7c-c110-40e0-bed8-a874d3d7226d)