### PR TITLE
allow custom filenaming

### DIFF
--- a/adafruit_pycamera/__init__.py
+++ b/adafruit_pycamera/__init__.py
@@ -827,7 +827,7 @@ See Learn Guide."""
         except OSError as exc:  # no SD card!
             raise RuntimeError("No SD card mounted") from exc
         while True:
-            filename = f"/sd/{filename_prefix}{self._image_counter}.{extension}"
+            filename = f"/sd/{filename_prefix}{self._image_counter:04d}.{extension}"
             self._image_counter += 1
             try:
                 os.stat(filename)

--- a/adafruit_pycamera/__init__.py
+++ b/adafruit_pycamera/__init__.py
@@ -827,10 +827,7 @@ See Learn Guide."""
         except OSError as exc:  # no SD card!
             raise RuntimeError("No SD card mounted") from exc
         while True:
-            filename = f"/sd/{filename_prefix}%04d.%s" % (
-                self._image_counter,
-                extension,
-            )
+            filename = f"/sd/{filename_prefix}{self._image_counter}.{extension}"
             self._image_counter += 1
             try:
                 os.stat(filename)

--- a/adafruit_pycamera/__init__.py
+++ b/adafruit_pycamera/__init__.py
@@ -820,14 +820,17 @@ See Learn Guide."""
         # self.effect = self._effect
         self.continuous_capture_start()
 
-    def open_next_image(self, extension="jpg"):
+    def open_next_image(self, extension="jpg", filename_prefix="img"):
         """Return an opened numbered file on the sdcard, such as "img01234.jpg"."""
         try:
             os.stat("/sd")
         except OSError as exc:  # no SD card!
             raise RuntimeError("No SD card mounted") from exc
         while True:
-            filename = "/sd/img%04d.%s" % (self._image_counter, extension)
+            filename = f"/sd/{filename_prefix}%04d.%s" % (
+                self._image_counter,
+                extension,
+            )
             self._image_counter += 1
             try:
                 os.stat(filename)
@@ -837,7 +840,7 @@ See Learn Guide."""
         print("Writing to", filename)
         return open(filename, "wb")
 
-    def capture_jpeg(self):
+    def capture_jpeg(self, filename_prefix="img"):
         """Capture a jpeg file and save it to the SD card"""
         try:
             os.stat("/sd")
@@ -855,7 +858,7 @@ See Learn Guide."""
             print(f"Captured {len(jpeg)} bytes of jpeg data")
             print("Resolution %d x %d" % (self.camera.width, self.camera.height))
 
-            with self.open_next_image() as dest:
+            with self.open_next_image(filename_prefix=filename_prefix) as dest:
                 chunksize = 16384
                 for offset in range(0, len(jpeg), chunksize):
                     dest.write(jpeg[offset : offset + chunksize])

--- a/examples/timestamp_filename/code.py
+++ b/examples/timestamp_filename/code.py
@@ -46,7 +46,6 @@ while True:
         pycam.tone(1600, 0.05)
         try:
             pycam.display_message("snap", color=0x00DD00)
-            # pylint: disable=line-too-long
             timestamp = "img_{}-{}-{}_{:02}-{:02}-{:02}_".format(
                 time.localtime().tm_year,
                 time.localtime().tm_mon,

--- a/examples/timestamp_filename/code.py
+++ b/examples/timestamp_filename/code.py
@@ -2,7 +2,10 @@
 #
 # SPDX-License-Identifier: MIT
 """ simple point-and-shoot camera example. With NTP and internal RTC to
- add timestamp to photo filenames. Must install adafruit_ntp library!"""
+ add timestamp to photo filenames. Must install adafruit_ntp library!
+ Example code assumes WIFI credentials are properly setup and web workflow
+ enabled in settings.toml. If not, you'll need to add code to manually connect
+ to your network."""
 
 import time
 import wifi

--- a/examples/timestamp_filename/code.py
+++ b/examples/timestamp_filename/code.py
@@ -5,12 +5,11 @@
  add timestamp to photo filenames. Must install adafruit_ntp library!"""
 
 import time
-import adafruit_pycamera  # pylint: disable=import-error
 import wifi
 import socketpool
-import adafruit_ntp
 import rtc
-import time
+import adafruit_ntp
+import adafruit_pycamera  # pylint: disable=import-error
 
 pool = socketpool.SocketPool(wifi.radio)
 ntp = adafruit_ntp.NTP(pool, tz_offset=0)
@@ -44,7 +43,11 @@ while True:
         pycam.tone(1600, 0.05)
         try:
             pycam.display_message("snap", color=0x00DD00)
-            timestamp = f"img_{time.localtime().tm_year}-{time.localtime().tm_mon}-{time.localtime().tm_mday}_{time.localtime().tm_hour:02}-{time.localtime().tm_min:02}-{time.localtime().tm_sec:02}_"
+            # pylint: disable=line-too-long
+            timestamp = (
+                f"img_{time.localtime().tm_year}-{time.localtime().tm_mon}-{time.localtime().tm_mday}"
+                f"_{time.localtime().tm_hour:02}-{time.localtime().tm_min:02}-{time.localtime().tm_sec:02}_"
+            )
             pycam.capture_jpeg(filename_prefix=timestamp)
             pycam.live_preview_mode()
         except TypeError as exception:

--- a/examples/timestamp_filename/code.py
+++ b/examples/timestamp_filename/code.py
@@ -47,7 +47,14 @@ while True:
         try:
             pycam.display_message("snap", color=0x00DD00)
             # pylint: disable=line-too-long
-            timestamp = f"img_{time.localtime().tm_year}-{time.localtime().tm_mon}-{time.localtime().tm_mday}_{time.localtime().tm_hour:02}-{time.localtime().tm_min:02}-{time.localtime().tm_sec:02}_"
+            timestamp = "img_{}-{}-{}_{:02}-{:02}-{:02}_".format(
+                time.localtime().tm_year,
+                time.localtime().tm_mon,
+                time.localtime().tm_mday,
+                time.localtime().tm_hour,
+                time.localtime().tm_min,
+                time.localtime().tm_sec,
+            )
             pycam.capture_jpeg(filename_prefix=timestamp)
             pycam.live_preview_mode()
         except TypeError as exception:

--- a/examples/timestamp_filename/code.py
+++ b/examples/timestamp_filename/code.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 Tim Cocks for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+""" simple point-and-shoot camera example. With NTP and internal RTC to
+ add timestamp to photo filenames. Must install adafruit_ntp library!"""
+
+import time
+import adafruit_pycamera  # pylint: disable=import-error
+import wifi
+import socketpool
+import adafruit_ntp
+import rtc
+import time
+
+pool = socketpool.SocketPool(wifi.radio)
+ntp = adafruit_ntp.NTP(pool, tz_offset=0)
+rtc.RTC().datetime = ntp.datetime
+
+pycam = adafruit_pycamera.PyCamera()
+pycam.mode = 0  # only mode 0 (JPEG) will work in this example
+
+# User settings - try changing these:
+pycam.resolution = 2  # 0-12 preset resolutions:
+#                      0: 240x240, 1: 320x240, 2: 640x480, 3: 800x600, 4: 1024x768,
+#                      5: 1280x720, 6: 1280x1024, 7: 1600x1200, 8: 1920x1080, 9: 2048x1536,
+#                      10: 2560x1440, 11: 2560x1600, 12: 2560x1920
+pycam.led_level = 1  # 0-4 preset brightness levels
+pycam.led_color = 0  # 0-7  preset colors: 0: white, 1: green, 2: yellow, 3: red,
+#                                          4: pink, 5: blue, 6: teal, 7: rainbow
+pycam.effect = 0  # 0-7 preset FX: 0: normal, 1: invert, 2: b&w, 3: red,
+#                                  4: green, 5: blue, 6: sepia, 7: solarize
+
+print("Simple camera ready.")
+pycam.tone(800, 0.1)
+pycam.tone(1200, 0.05)
+
+while True:
+    pycam.blit(pycam.continuous_capture())
+    pycam.keys_debounce()
+
+    if pycam.shutter.short_count:
+        print("Shutter released")
+        pycam.tone(1200, 0.05)
+        pycam.tone(1600, 0.05)
+        try:
+            pycam.display_message("snap", color=0x00DD00)
+            timestamp = f"img_{time.localtime().tm_year}-{time.localtime().tm_mon}-{time.localtime().tm_mday}_{time.localtime().tm_hour:02}-{time.localtime().tm_min:02}-{time.localtime().tm_sec:02}_"
+            pycam.capture_jpeg(filename_prefix=timestamp)
+            pycam.live_preview_mode()
+        except TypeError as exception:
+            pycam.display_message("Failed", color=0xFF0000)
+            time.sleep(0.5)
+            pycam.live_preview_mode()
+        except RuntimeError as exception:
+            pycam.display_message("Error\nNo SD Card", color=0xFF0000)
+            time.sleep(0.5)
+
+    if pycam.card_detect.fell:
+        print("SD card removed")
+        pycam.unmount_sd_card()
+        pycam.display.refresh()
+
+    if pycam.card_detect.rose:
+        print("SD card inserted")
+        pycam.display_message("Mounting\nSD Card", color=0xFFFFFF)
+        for _ in range(3):
+            try:
+                print("Mounting card")
+                pycam.mount_sd_card()
+                print("Success!")
+                break
+            except OSError as exception:
+                print("Retrying!", exception)
+                time.sleep(0.5)
+        else:
+            pycam.display_message("SD Card\nFailed!", color=0xFF0000)
+            time.sleep(0.5)
+        pycam.display.refresh()

--- a/examples/timestamp_filename/code.py
+++ b/examples/timestamp_filename/code.py
@@ -47,10 +47,7 @@ while True:
         try:
             pycam.display_message("snap", color=0x00DD00)
             # pylint: disable=line-too-long
-            timestamp = (
-                f"img_{time.localtime().tm_year}-{time.localtime().tm_mon}-{time.localtime().tm_mday}"
-                f"_{time.localtime().tm_hour:02}-{time.localtime().tm_min:02}-{time.localtime().tm_sec:02}_"
-            )
+            timestamp = f"img_{time.localtime().tm_year}-{time.localtime().tm_mon}-{time.localtime().tm_mday}_{time.localtime().tm_hour:02}-{time.localtime().tm_min:02}-{time.localtime().tm_sec:02}_"
             pycam.capture_jpeg(filename_prefix=timestamp)
             pycam.live_preview_mode()
         except TypeError as exception:


### PR DESCRIPTION
This change allows you to pass a custom string to get used instead of the default "img" in the photo filenames. 

It will still include the 4 digit integer counter for ensuring unique names. 

resolves #17 