### PR TITLE
Overlay scale

### DIFF
--- a/adafruit_pycamera/__init__.py
+++ b/adafruit_pycamera/__init__.py
@@ -240,6 +240,7 @@ class PyCameraBase:  # pylint: disable=too-many-instance-attributes,too-many-pub
         self.combined_bmp = None
         self.preview_scale = None
         self.overlay_position = [None, None]
+        self.overlay_scale = 1.0
         self.splash = displayio.Group()
 
         # Reset display and I/O expander
@@ -929,13 +930,15 @@ See Learn Guide."""
 
         self.decoder.decode(photo_bitmap, scale=0, x=0, y=0)
 
-        bitmaptools.blit(
+        bitmaptools.rotozoom(
             photo_bitmap,
             self.overlay_bmp,
-            self.overlay_position[0] if self.overlay_position[0] is not None else 0,
-            self.overlay_position[1] if self.overlay_position[1] is not None else 0,
-            skip_source_index=self.overlay_transparency_color,
-            skip_dest_index=None,
+            ox=self.overlay_position[0] if self.overlay_position[0] is not None else 0,
+            oy=self.overlay_position[1] if self.overlay_position[1] is not None else 0,
+            px=0 if self.overlay_position[0] is not None else None,
+            py=0 if self.overlay_position[1] is not None else None,
+            skip_index=self.overlay_transparency_color,
+            scale=self.overlay_scale,
         )
 
         cc565_swapped = ColorConverter(input_colorspace=Colorspace.RGB565_SWAPPED)
@@ -1007,7 +1010,7 @@ See Learn Guide."""
             bitmaptools.rotozoom(
                 self.combined_bmp,
                 self.overlay_bmp,
-                scale=self.preview_scale,
+                scale=self.preview_scale * self.overlay_scale,
                 skip_index=self.overlay_transparency_color,
                 ox=int(self.overlay_position[0] * self.preview_scale)
                 if self.overlay_position[0] is not None

--- a/examples/overlay/code_select.py
+++ b/examples/overlay/code_select.py
@@ -2,21 +2,20 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 Tim Cocks for Adafruit Industries
 #
 # SPDX-License-Identifier: MIT
-""" simple point-and-shoot camera example, with overly capabilities.
+""" simple point-and-shoot camera example, with overly selecting using select button.
 
 Place all overlay files inside /sd/overlays/ directory.
-
-Usage:
-
-Select Button - Change to the next overlay file
-OK Button - Change between position and scale modes
-D-Pad - Change the overlay's position or scale depending on which mode
-  we're currently in.
 """
 import os
 import time
 import traceback
 import adafruit_pycamera  # pylint: disable=import-error
+
+MODE_POSITION = 0
+MODE_SCALE = 1
+CURRENT_MODE = 0
+
+int_scale = 100
 
 pycam = adafruit_pycamera.PyCamera()
 pycam.mode = 0  # only mode 0 (JPEG) will work in this example
@@ -56,16 +55,34 @@ while True:
         print(f"changing overlay to {overlay_files[cur_overlay_idx]}")
         pycam.overlay = f"/sd/overlays/{overlay_files[cur_overlay_idx]}"
 
-    if not pycam.down.value:
-        pycam.overlay_position[1] += 1 * (int(pycam.down.current_duration / 0.3) + 1)
-    if not pycam.up.value:
-        pycam.overlay_position[1] -= 1 * (int(pycam.up.current_duration / 0.3) + 1)
+    if CURRENT_MODE == MODE_POSITION:
+        if not pycam.down.value:
+            pycam.overlay_position[1] += 1 * (
+                int(pycam.down.current_duration / 0.3) + 1
+            )
+        if not pycam.up.value:
+            pycam.overlay_position[1] -= 1 * (int(pycam.up.current_duration / 0.3) + 1)
+        if not pycam.left.value:
+            pycam.overlay_position[0] -= 1 * (
+                int(pycam.left.current_duration / 0.3) + 1
+            )
+        if not pycam.right.value:
+            pycam.overlay_position[0] += 1 * (
+                int(pycam.right.current_duration / 0.3) + 1
+            )
+    if CURRENT_MODE == MODE_SCALE:
+        if pycam.down.fell:
+            int_scale -= 10
+            pycam.overlay_scale = int_scale / 100
+            print(pycam.overlay_scale)
+        if pycam.up.fell:
+            int_scale += 10
+            pycam.overlay_scale = int_scale / 100
+            print(pycam.overlay_scale)
 
-    if not pycam.left.value:
-        pycam.overlay_position[0] -= 1 * (int(pycam.left.current_duration / 0.3) + 1)
-    if not pycam.right.value:
-        pycam.overlay_position[0] += 1 * (int(pycam.right.current_duration / 0.3) + 1)
-
+    if pycam.ok.fell:
+        CURRENT_MODE = MODE_POSITION if CURRENT_MODE == MODE_SCALE else MODE_SCALE
+        print(f"Changing mode to: {CURRENT_MODE}")
     if pycam.shutter.short_count:
         print("Shutter released")
         pycam.tone(1200, 0.05)

--- a/examples/overlay/code_select.py
+++ b/examples/overlay/code_select.py
@@ -2,9 +2,16 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 Tim Cocks for Adafruit Industries
 #
 # SPDX-License-Identifier: MIT
-""" simple point-and-shoot camera example, with overly selecting using select button.
+""" simple point-and-shoot camera example, with overly capabilities.
 
 Place all overlay files inside /sd/overlays/ directory.
+
+Usage:
+
+Select Button - Change to the next overlay file
+OK Button - Change between position and scale modes
+D-Pad - Change the overlay's position or scale depending on which mode
+  we're currently in.
 """
 import os
 import time


### PR DESCRIPTION
This adds an `overlay_scale` property which is a float that defaults to 1.0. The overlay will get scaled by this value in both the preview and final photo that the overlay is pasted into. 

The more advanced overlay select example has been updated to utilize an extra button to change between position and scale selection modes. The D-Pad will change scale or position based on which mode it's in. 