### PR TITLE
fix docs badge link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Introduction
 ============
 
 
-.. image:: https://readthedocs.org/projects/adafruit-circuitpython-pycamera/badge/?version=latest
+.. image:: https://readthedocs.org/projects/circuitpython-pycamera/badge/?version=latest
     :target: https://docs.circuitpython.org/projects/pycamera/en/latest/
     :alt: Documentation Status
 


### PR DESCRIPTION
For some reason this project inside of RTD does not have "adafruit-" prepended to it's name so the badge link that was here before shows "Unknown". This corrects it to match the name in RTD to get the correct badge for this project's latest build.