### PR TITLE
use espcamera reset functionality; other minor changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/pycqa/pylint
-    rev: v2.17.4
+    rev: v3.3.1
     hooks:
       - id: pylint
         name: pylint (library code)

--- a/examples/filter/code.py
+++ b/examples/filter/code.py
@@ -139,8 +139,7 @@ effects = [
 
 def cycle(seq):
     while True:
-        for s in seq:
-            yield s
+        yield from seq
 
 
 effects_cycle = iter(cycle(effects))


### PR DESCRIPTION
- espcamera knows how to toggle the power and reset pins to do a reset. Let it do it instead of doing it in Python code.
- Make docstring be one string
- use I2C `write_then_readinto()`

I made these changes while debugging ESP-IDF new I2C driver support.