### PR TITLE
Rtd badge url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Introduction
 ============
 
 
-.. image:: https://readthedocs.org/projects/adafruit-circuitpython-pycamera/badge/?version=latest
+.. image:: https://readthedocs.org/projects/pycamera/badge/?version=latest
     :target: https://docs.circuitpython.org/projects/pycamera/en/latest/
     :alt: Documentation Status
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Introduction
 ============
 
 
-.. image:: https://readthedocs.org/projects/pycamera/badge/?version=latest
+.. image:: https://readthedocs.org/projects/circuitpython-pycamera/badge/?version=latest
     :target: https://docs.circuitpython.org/projects/pycamera/en/latest/
     :alt: Documentation Status
 


### PR DESCRIPTION
the rtd slug for this project is `circuitpython-pycamera` https://app.readthedocs.org/projects/circuitpython-pycamera/builds/.

This being mismatched also causes issues for adabot, first noticed here: https://github.com/adafruit/adabot/pull/394