### PR TITLE
Fix typo in setting name from 'timelaps_rate' to 'timelapse_rate'

### DIFF
--- a/examples/camera/code.py
+++ b/examples/camera/code.py
@@ -263,7 +263,7 @@ while True:
     if pycam.left.fell:
         print("LF")
         curr_setting = (curr_setting - 1 + len(settings)) % len(settings)
-        if pycam.mode_text != "LAPS" and settings[curr_setting] == "timelaps_rate":
+        if pycam.mode_text != "LAPS" and settings[curr_setting] == "timelapse_rate":
             curr_setting = (curr_setting + 1) % len(settings)
         print(settings[curr_setting])
         pycam.select_setting(settings[curr_setting])


### PR DESCRIPTION
In the left.fell button handler, the setting name was spelled "timelaps_rate" instead of "timelapse_rate". This never matched any entry in the settings tuple, so the timelapse_rate setting was never skipped when navigating left outside of LAPS mode unlike the right.fell handler which had the correct spelling and worked as expected.

What was changed:
Single character fix on the typo "timelaps_rate" to "timelapse_rate"