### PR TITLE
Improve WiFi connection logic and error handling

### DIFF
--- a/examples/camera/code.py
+++ b/examples/camera/code.py
@@ -263,7 +263,7 @@ while True:
     if pycam.left.fell:
         print("LF")
         curr_setting = (curr_setting - 1 + len(settings)) % len(settings)
-        if pycam.mode_text != "LAPS" and settings[curr_setting] == "timelaps_rate":
+        if pycam.mode_text != "LAPS" and settings[curr_setting] == "timelapse_rate":
             curr_setting = (curr_setting + 1) % len(settings)
         print(settings[curr_setting])
         pycam.select_setting(settings[curr_setting])

--- a/examples/camera/code.py
+++ b/examples/camera/code.py
@@ -32,27 +32,29 @@ SSID = os.getenv("CIRCUITPY_WIFI_SSID")
 PASSWORD = os.getenv("CIRCUITPY_WIFI_PASSWORD")
 
 if SSID and PASSWORD:
-    wifi.radio.connect(os.getenv("CIRCUITPY_WIFI_SSID"), os.getenv("CIRCUITPY_WIFI_PASSWORD"))
-    if wifi.radio.connected:
-        print(f"Connected to {os.getenv('CIRCUITPY_WIFI_SSID')}!")
-        print("My IP address is", wifi.radio.ipv4_address)
-        pool = socketpool.SocketPool(wifi.radio)
+    try:
+        wifi.radio.connect(SSID, PASSWORD)
+        if wifi.radio.connected:
+            print(f"Connected to {SSID}!")
+            print("My IP address is", wifi.radio.ipv4_address)
+            pool = socketpool.SocketPool(wifi.radio)
 
-        if UTC_OFFSET is None:
-            requests = adafruit_requests.Session(pool, ssl.create_default_context())
-            response = requests.get("http://worldtimeapi.org/api/timezone/" + TZ)
-            response_as_json = response.json()
-            UTC_OFFSET = response_as_json["raw_offset"] + response_as_json["dst_offset"]
-            print(f"UTC_OFFSET: {UTC_OFFSET}")
+            if UTC_OFFSET is None:
+                requests = adafruit_requests.Session(pool, ssl.create_default_context())
+                response = requests.get("http://worldtimeapi.org/api/timezone/" + TZ)
+                response_as_json = response.json()
+                UTC_OFFSET = response_as_json["raw_offset"] + response_as_json["dst_offset"]
+                print(f"UTC_OFFSET: {UTC_OFFSET}")
 
-        ntp = adafruit_ntp.NTP(pool, server="pool.ntp.org", tz_offset=UTC_OFFSET // 3600)
-
-        print(f"ntp time: {ntp.datetime}")
-        rtc.RTC().datetime = ntp.datetime
-    else:
-        print("Wifi failed to connect. Time not set.")
+            ntp = adafruit_ntp.NTP(pool, server="pool.ntp.org", tz_offset=UTC_OFFSET // 3600)
+            print(f"ntp time: {ntp.datetime}")
+            rtc.RTC().datetime = ntp.datetime
+        else:
+            print("Wifi failed to connect. Time not set.")
+    except Exception as e:
+        print(f"Wifi error: {e}. Continuing without network.")
 else:
-    print("Wifi config not found in settintgs.toml. Time not set.")
+    print("Wifi config not found in settings.toml. Time not set.")
 
 pycam = adafruit_pycamera.PyCamera()
 # pycam.live_preview_mode()


### PR DESCRIPTION
During testing this code on the Memento board ,it was resulting in a crash. When I checked I saw that the WiFi connection call had no error handling. If the network was unavailable, out of range, or wrong frequency (e.g. 5GHz-only), a ConnectionError was raised and the entire program crashed making the camera completely unusable even though WiFi is optional functionality.
<img width="1334" height="1524" alt="image" src="https://github.com/user-attachments/assets/d966f0a5-fe76-4c98-927e-8d1364ceab57" />



Fix: Wrapped the wifi.radio.connect() block in a try/except Exception so that any connection failure is caught, printed to serial, and the program continues to run normally without network access.

<img width="1487" height="981" alt="image" src="https://github.com/user-attachments/assets/7c7cbc1d-ab3f-4fa8-bb8e-f3c9c86e1ee4" />

<img width="3294" height="1258" alt="image" src="https://github.com/user-attachments/assets/1f07cf5e-bff7-4845-842e-47ac1483fc9b" />
